### PR TITLE
cloudbuild: add comment_control

### DIFF
--- a/terraform/envs/gcp_prod/.bootstrap_resources/google_cloudbuild.tf
+++ b/terraform/envs/gcp_prod/.bootstrap_resources/google_cloudbuild.tf
@@ -8,7 +8,8 @@ module "google_cloudbuild_tf_plan_for_pr" {
     owner = "hkak03key"
     name  = "pj-ray-kisaragi"
     pull_request = {
-      branch = ".*"
+      branch          = ".*"
+      comment_control = "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY"
     }
   }
   proc = "plan"

--- a/terraform/envs/gcp_prod/.bootstrap_resources/locals.tf
+++ b/terraform/envs/gcp_prod/.bootstrap_resources/locals.tf
@@ -1,4 +1,4 @@
 locals {
-  project_id   = data.google_project.project.number
+  project_id = data.google_project.project.number
 }
 

--- a/terraform/envs/gcp_prod/.bootstrap_resources/terraform.tfstate
+++ b/terraform/envs/gcp_prod/.bootstrap_resources/terraform.tfstate
@@ -1,7 +1,7 @@
 {
   "version": 4,
   "terraform_version": "1.0.2",
-  "serial": 11,
+  "serial": 13,
   "lineage": "499c1353-e6ef-77c5-ed53-e5bd957bbb95",
   "outputs": {
     "project_name": {
@@ -44,7 +44,7 @@
           "schema_version": 0,
           "attributes": {
             "condition": [],
-            "etag": "BwXIyiN5BfE=",
+            "etag": "BwXIyiuBhEQ=",
             "id": "1015403302639/roles/admin",
             "members": [
               "serviceAccount:1015403302639@cloudbuild.gserviceaccount.com"
@@ -394,7 +394,7 @@
                 "pull_request": [
                   {
                     "branch": ".*",
-                    "comment_control": "",
+                    "comment_control": "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY",
                     "invert_regex": false
                   }
                 ],
@@ -417,8 +417,7 @@
           "sensitive_attributes": [],
           "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoyNDAwMDAwMDAwMDAsImRlbGV0ZSI6MjQwMDAwMDAwMDAwLCJ1cGRhdGUiOjI0MDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
           "dependencies": [
-            "google_project_service.services",
-            "data.google_project.project"
+            "google_project_service.services"
           ]
         }
       ]

--- a/terraform/envs/gcp_prod/.bootstrap_resources/terraform.tfstate.backup
+++ b/terraform/envs/gcp_prod/.bootstrap_resources/terraform.tfstate.backup
@@ -1,7 +1,7 @@
 {
   "version": 4,
   "terraform_version": "1.0.2",
-  "serial": 9,
+  "serial": 11,
   "lineage": "499c1353-e6ef-77c5-ed53-e5bd957bbb95",
   "outputs": {
     "project_name": {
@@ -31,6 +31,32 @@
             "skip_delete": null
           },
           "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "google_project_iam_binding",
+      "name": "cloudbuild",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "condition": [],
+            "etag": "BwXIyiN5BfE=",
+            "id": "1015403302639/roles/admin",
+            "members": [
+              "serviceAccount:1015403302639@cloudbuild.gserviceaccount.com"
+            ],
+            "project": "1015403302639",
+            "role": "roles/admin"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "data.google_project.project"
+          ]
         }
       ]
     },
@@ -91,7 +117,7 @@
             "encryption": [],
             "force_destroy": false,
             "id": "pj-ray-kisaragi-prod-terraform",
-            "labels": null,
+            "labels": {},
             "lifecycle_rule": [
               {
                 "action": [
@@ -391,8 +417,8 @@
           "sensitive_attributes": [],
           "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoyNDAwMDAwMDAwMDAsImRlbGV0ZSI6MjQwMDAwMDAwMDAwLCJ1cGRhdGUiOjI0MDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
           "dependencies": [
-            "data.google_project.project",
-            "google_project_service.services"
+            "google_project_service.services",
+            "data.google_project.project"
           ]
         }
       ]


### PR DESCRIPTION
### やったこと
cloudbuildのcomment controlを追加

### 参照
- https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger#comment_control
- https://cloud.google.com/build/docs/automating-builds/create-github-app-triggers
